### PR TITLE
fixing nils feedback

### DIFF
--- a/src/app/users/[id]/groups/[groupId]/vote/page.tsx
+++ b/src/app/users/[id]/groups/[groupId]/vote/page.tsx
@@ -531,8 +531,8 @@ const Vote: React.FC = () => {
       )}
       {/* Overlay success for saved ranking only */}
       {successMessage === "Saved your Ranking" && showSuccessMessage && (
-        <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-50">
-          <div className="bg-green-500 text-white px-6 py-3 rounded shadow-lg">
+          <div className="fixed bottom-8 left-1/2 transform -translate-x-1/2 z-50">
+            <div className="bg-green-500 text-white px-6 py-3 rounded shadow-lg">
             {successMessage}
           </div>
         </div>


### PR DESCRIPTION
The “Saved your ranking” notification is in the middle of the screen while other 
notifications are on the bottom, try to unify this.